### PR TITLE
Trigger Prefix Message

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -7,10 +7,12 @@ channels:
     channel-secret: your-channel-secret
     channel-access-token: your-channel-access-token
     llm-endpoint: url-of-your-llm-endpoint # LLM endpoint for channel 1.
+    trigger-word: "Hello" # Trigger word for channel 1.
   2: # Your channel ID.
     channel-secret: your-channel-secret
     channel-access-token: your-channel-access-token
     llm-endpoint: url-of-your-llm-endpoint # LLM endpoint for channel 2.
+    trigger-word: "Hello" # Trigger word for channel 2.
 max-concurrent-event-handlers: 5 # Max concurrent handler threads.
 address: 0.0.0.0 # Address to listen on.
 port: 443 # Port to listen on.

--- a/server_prototype.go
+++ b/server_prototype.go
@@ -23,9 +23,10 @@ type response struct {
 
 // Definiton of the channel struct.
 type Channel struct {
-	ChannelSecret      string `yaml:"channel-secret"`       // The secret of the channel, get it from TaipeiON admin panel.
-	ChannelAccessToken string `yaml:"channel-access-token"` // The access token of the channel.
-	ChannelLlmEndpoint string `yaml:"llm-endpoint"`         // The endpoint of the LLM server for this channel.
+	ChannelSecret        string `yaml:"channel-secret"`       // The secret of the channel, get it from TaipeiON admin panel.
+	ChannelAccessToken   string `yaml:"channel-access-token"` // The access token of the channel.
+	ChannelLlmEndpoint   string `yaml:"llm-endpoint"`         // The endpoint of the LLM server for this channel.
+	ChannelTriggerPrefix string `yaml:"trigger-word"`         // The trigger word for this channel.
 }
 
 type ChannelIdConfigMap map[int]Channel // A map from channel ID to channel configuration.


### PR DESCRIPTION
Now we implemented message prefix, which can ignore certain message if it doesn't have some prefix.

To define a channel prefix, edit `config.yaml` as follows.
```yaml
  1: # Your channel ID.
    channel-secret: your-channel-secret
    channel-access-token: your-channel-access-token
    llm-endpoint: url-of-your-llm-endpoint # LLM endpoint for channel 1.
    trigger-word: "Hello" # Trigger word for channel 1.
```

If an incoming doesn't start with "hello", the message will be ignored.

NOTE: If a `trigger-word` is not defined, all incoming message will be processed.
