### PR TITLE
Feature: LLM local debug flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ config.yaml
 taipeion_server
 
 .DS_Store
+
+docker-compose-sample.yaml

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	// Create a new chatbot instance
 	bot := NewChatbotFromConfig(config)
 
-	llm := NewLlmConnector(config.Channels)
+	llm := NewLlmConnector(config.Channels, *llmDebug)
 
 	// Register callbacks.
 	bot.RegisterWebhookEventCallback(

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func loadConfig(configPath string) ServerConfig {
 func main() {
 	// Define command-line flags
 	configPath := flag.String("config", "config.yaml", "Path to the config file")
-	llmDebug := flag.Bool("llm-debug", false, "Enable debug mode for LLM")
+	llmDebug := flag.Bool("llm-local-debug", false, "Enable local debug mode for LLM, preventing requests to the LLM endpoint")
 
 	// Parse command-line flags
 	flag.Parse()

--- a/server_llm_connector.go
+++ b/server_llm_connector.go
@@ -74,7 +74,15 @@ func (c *LlmConnector) LlmCallback(bot *TaipeionBot, event ChatbotWebhookEvent) 
 		log.Printf("[LlmCallback] User query does not start with trigger word (%s). Ignoring.\n", trigger_word)
 		return nil
 	}
+	// Check debug mode.
+	if c.LocalDebugMode {
+		log.Println("[LlmCallback] Local debug mode is enabled.")
+		log.Printf("[LlmCallback] [Debug info] User ID: %s, Channel ID: %d, User Query: %s Trigger Word: %s\n", userId, chan_id, userQuery, trigger_word)
+		log.Println("[LlmCallback] The following procedure is sending the user query to the LLM server in normal mode.")
+		log.Println("[LlmCallback] LLM Callback will now exit.")
 
+		return nil
+	}
 	// Send a friendly message.
 	err := bot.SendPrivateMessage(userId, fmt.Sprintf("正在處理您的問題，視當前情況大約需要30秒~數分鐘不等\n感謝您的耐心等待!\n(目前排隊: %d)", c.waitingCounter), chan_id)
 


### PR DESCRIPTION
Add an option to enable local debug mode.

If local debug mode is enabled, the LLM connector won't send query to LLM server. It is convenient for debug basic bot architecture.